### PR TITLE
Changed the amp template to not integrate a game port. As amp can use…

### DIFF
--- a/amp.xml
+++ b/amp.xml
@@ -77,7 +77,6 @@
   </Environment>
   <Labels/>
   <Config Name="Port" Target="8080" Default="8080" Mode="tcp" Description="Web Interface Port" Type="Port" Display="always" Required="false" Mask="false">8080</Config>
-  <Config Name="Game Port" Target="25565" Default="25565" Mode="tcp" Description="Port for you game. Please make additional ports if needed. See support thread for help." Type="Port" Display="always" Required="false" Mask="false">25565</Config>
   <Config Name="AMP License" Target="LICENCE" Default="" Mode="" Description="Your AMP or McMyAdmin license." Type="Variable" Display="always" Required="true" Mask="false"/>
   <Config Name="Module" Target="MODULE" Default="ADS" Mode="" Description="Which Module to use for the main instance created by this image. ADS allows you to create multiple modules." Type="Variable" Display="always" Required="true" Mask="false">ADS</Config>
   <Config Name="Username" Target="USERNAME" Default="admin" Mode="" Description="The username of the admin user created on first boot." Type="Variable" Display="always" Required="true" Mask="false">admin</Config>


### PR DESCRIPTION
… alot of ports for various games its smarter to set those manually. Additionally if having ports already configured for minecraft as an example with port 25565 and amp receives an update, the template updates as well and adds the game port back in, which causes docker to be unable to start amp as port 25565 is then already taken.